### PR TITLE
Add custom Sanity groq projections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
This commit adds the option to customize how documents are fetched from Sanity, before you map them into Algolia records. With customized projections it is easy to resolve references or be very specific about which values you need in your Algolia records. If you don't specify a projection it will fetch the full document as-is.

Note that the API has changed slightly and this will be a major version bump.