### PR TITLE
fix(flattenBlocks): check if text property exists

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -29,7 +29,10 @@ export const flattenBlocks = (
         .filter((i) => i._type === 'block')
         .map((b) =>
           b.children
-            .filter((c: Record<string, any>) => c.text.length > 0)
+            .filter(
+              (c: Record<string, any>) =>
+                typeof c.text === 'string' && c.text.length > 0
+            )
             .map((c: Record<string, any>) => {
               if (removeStopWords) {
                 return sw.removeStopwords(c.text.split(' ')).join(' ')


### PR DESCRIPTION
## Summary

This PR add a filter to check if `text` property exists.

I have a custom schema that doens't have `text` property and it's one of the children of `document.body`.

I didn't add any test, but feel free to update this PR to add any test if needed.