### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import sanityClient, { SanityDocumentStub } from '@sanity/client'
 import { NowRequest, NowResponse } from '@vercel/node'
 import indexer, { flattenBlocks } from 'sanity-algolia'
 
-const algolia = algoliasearch('application-id', 'api-key')
+const algolia = algoliasearch('application-id', process.env.ALGOLIA_ADMIN_API_KEY)
 const sanity = sanityClient({
   projectId: 'my-sanity-project-id',
   dataset: 'my-dataset-name',


### PR DESCRIPTION
Algolia provides 2 types of key:

- search only api key
- admin api key

In this context, we need the latter to create/update records. However it's not meant to be exposed to public (like on frontend code, or in GitHub repo). So we recommend people to put it in the environment variable and let them access it like this.

What do you think?