### PR TITLE
Handle returning an array in serialize method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-algolia",
-  "version": "0.2.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1911,12 +1911,12 @@
       }
     },
     "@sanity/client": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-2.1.0.tgz",
-      "integrity": "sha512-CrxBa0h8Ov0cW09w35dh8gYOMyMlC6g/rqPQpyUS6Yo08uUOO/6nX8cJh+jug+TBb/V72yD0WpxRNhBWAFXU7w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-2.8.0.tgz",
+      "integrity": "sha512-S/EYj4SOJ4OMOOULCjNE2moFsb4h2Vy9zV/v4dOappal+GBxafJ9E/J4+qLhkMZqd2hTfECfawjshuoUUo+L+g==",
       "requires": {
-        "@sanity/eventsource": "2.0.1",
-        "@sanity/generate-help-url": "2.0.9",
+        "@sanity/eventsource": "2.2.6",
+        "@sanity/generate-help-url": "2.2.6",
         "@sanity/observable": "2.0.9",
         "deep-assign": "^2.0.0",
         "get-it": "^5.0.3",
@@ -1925,18 +1925,18 @@
       }
     },
     "@sanity/eventsource": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-2.0.1.tgz",
-      "integrity": "sha512-5FjMSEdXEv8QDyHeY82SMqL95wmGkDtLT5VPOrok/hqmc5MyfH0g/yo6HLfVwZbqmdQxnCZ37YUJ5vkyixfLTw==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-2.2.6.tgz",
+      "integrity": "sha512-RcrX/+sQwHfvNO3Fpie9rwi4RKTjaxN2BmaoJ9VayrbkL+12Tf1wcqwerPfR+VRA15c7NnLlDFCdu+iKpa7Tng==",
       "requires": {
         "@rexxars/eventsource-polyfill": "^1.0.0",
         "eventsource": "^1.0.6"
       }
     },
     "@sanity/generate-help-url": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-2.0.9.tgz",
-      "integrity": "sha512-Ibr4fEL3McAtvScwVPi5IpnLT+fXfY5NMxjmX0IyLHTod1iwOVpVlPBjWdLiiWiaMqX7Kf9CtoNcjFhtsVj2UA=="
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-2.2.6.tgz",
+      "integrity": "sha512-DXRKXnOCoqObNEEuJJlJ78YOehgoBk92xm1ol4PfPuD4xJv5Z/cMwDecaQ2K05nx8Ecr4KJR/26XMF/FQMg9Tw=="
     },
     "@sanity/observable": {
       "version": "2.0.9",
@@ -3912,9 +3912,9 @@
       "dev": true
     },
     "eventsource": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
-      "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
+      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
       "requires": {
         "original": "^1.0.0"
       }
@@ -4303,9 +4303,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -4414,9 +4414,9 @@
       }
     },
     "get-it": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/get-it/-/get-it-5.0.3.tgz",
-      "integrity": "sha512-S/QxA9/P4e0tHPILIdf92FVYrE0vre7ChXXMZoILuU4/keatMqnW1KAzCEOH8toJVbj+hgrOnZdUxd9ruG7lsQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/get-it/-/get-it-5.0.4.tgz",
+      "integrity": "sha512-gFCtVjKf6NB9uTVRIFsiBVFlEeiRDDs9/sNXFt/f5VYrmRd/1Wja6ZTMoI98rGcf89q1LtECUktRTz6EQ8aQMg==",
       "requires": {
         "@sanity/timed-out": "^4.0.2",
         "create-error-class": "^3.0.2",
@@ -9945,9 +9945,9 @@
       "dev": true
     },
     "url-parse": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "@sanity/client": "^2.0.1",
+    "@sanity/client": "^2.8.0",
     "algoliasearch": "^4.5.1",
     "stopword": "^1.0.3"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,8 +47,8 @@ const indexer = (
       (document: SanityDocumentStub) => {
         const serializedDocs = serializer(document)
         if (Array.isArray(serializedDocs)) {
-          return serializedDocs.map((chunk, index) =>
-            Object.assign(standardValues(chunk, String(index)), chunk)
+          return serializedDocs.map((chunk) =>
+            Object.assign(standardValues(chunk), chunk)
           )
         } else {
           return Object.assign(standardValues(document), serializedDocs)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import {SearchIndex} from 'algoliasearch'
-import {standardValues, sleep} from './util'
-import {SanityDocumentStub, SanityClient} from '@sanity/client'
+import { SearchIndex } from 'algoliasearch'
+import { standardValues, sleep } from './util'
+import { SanityDocumentStub, SanityClient } from '@sanity/client'
 import {
   AlgoliaRecord,
   SerializeFunction,
@@ -8,7 +8,7 @@ import {
   WebhookBody,
 } from './types'
 
-export {flattenBlocks} from './util'
+export { flattenBlocks } from './util'
 
 type TypeConfig = {
   index: SearchIndex
@@ -40,7 +40,7 @@ const indexer = (
   serializer: SerializeFunction,
   // Optionally provide logic for which documents should be visible or not.
   // Useful if your documents have a isHidden or isIndexed property or similar
-  visible?: VisiblityFunction,
+  visible?: VisiblityFunction
 ) => {
   const transform = (documents: SanityDocumentStub[]) => {
     const records: AlgoliaRecord[] = documents.map(
@@ -48,12 +48,12 @@ const indexer = (
         const serializedDocs = serializer(document)
         if (Array.isArray(serializedDocs)) {
           return serializedDocs.map((chunk, index) =>
-            Object.assign(standardValues(chunk, String(index)), chunk),
+            Object.assign(standardValues(chunk, String(index)), chunk)
           )
         } else {
           return Object.assign(standardValues(document), serializedDocs)
         }
-      },
+      }
     )
     return records.flat()
   }
@@ -70,9 +70,9 @@ const indexer = (
     // Fetch the full objects that we are probably going to index in Algolia. Some
     // of these might get filtered out later by the optional visibility function.
     const query = `* [(_id in $created || _id in $updated) && _type in $types] ${indexMapProjection(
-      typeIndexMap,
+      typeIndexMap
     )}`
-    const {created, updated} = body.ids
+    const { created, updated } = body.ids
     const docs: SanityDocumentStub[] = await client.fetch(query, {
       created,
       updated,
@@ -91,7 +91,7 @@ const indexer = (
     })
     const visibleIds = visibleRecords.map((doc: any) => doc._id)
     const hiddenIds = allCreatedOrUpdated.filter(
-      (id: string) => !visibleIds.includes(id),
+      (id: string) => !visibleIds.includes(id)
     )
 
     const recordsToSave = transform(visibleRecords)
@@ -99,7 +99,7 @@ const indexer = (
     if (recordsToSave.length > 0) {
       for (const type in typeIndexMap) {
         await typeIndexMap[type].index.saveObjects(
-          recordsToSave.filter((r) => r.type === type),
+          recordsToSave.filter((r) => r.type === type)
         )
       }
     }
@@ -110,7 +110,7 @@ const indexer = (
      * before. Right now we blankly tell Algolia to try to delete any deleted record
      * in any index we have.
      */
-    const {deleted} = body.ids
+    const { deleted } = body.ids
     const recordsToDelete = deleted.concat(hiddenIds)
 
     if (recordsToDelete.length > 0) {
@@ -120,7 +120,7 @@ const indexer = (
     }
   }
 
-  return {transform, webhookSync}
+  return { transform, webhookSync }
 }
 
 export default indexer

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,20 +1,17 @@
 // We do this locally just to trim the size of the records a bit
 import sw from 'stopword'
-import {SanityDocumentStub} from '@sanity/client'
-import {SearchIndex} from 'algoliasearch'
-import {AlgoliaRecord} from 'types'
+import { SanityDocumentStub } from '@sanity/client'
+import { SearchIndex } from 'algoliasearch'
+import { AlgoliaRecord } from 'types'
 
 export const sleep = (ms: number) => {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 // Properties that always should exist (only objectID is strictly needed from Algolia)
-export const standardValues = (
-  doc: SanityDocumentStub,
-  objectIdModifier?: string,
-) => {
+export const standardValues = (doc: SanityDocumentStub) => {
   return {
-    objectID: objectIdModifier ? `${doc._id}-${objectIdModifier}` : doc._id,
+    objectID: doc._id,
     type: doc._type,
     rev: doc._rev,
   }
@@ -23,7 +20,7 @@ export const standardValues = (
 // TODO: Probably want to support other languages besides English for the stopwords
 export const flattenBlocks = (
   blocks: Record<string, any>[],
-  removeStopWords = false,
+  removeStopWords = false
 ) => {
   return [].concat
     .apply(
@@ -34,15 +31,15 @@ export const flattenBlocks = (
           b.children
             .filter(
               (c: Record<string, any>) =>
-                typeof c.text === 'string' && c.text.length > 0,
+                typeof c.text === 'string' && c.text.length > 0
             )
             .map((c: Record<string, any>) => {
               if (removeStopWords) {
                 return sw.removeStopwords(c.text.split(' ')).join(' ')
               }
               return c.text
-            }),
-        ),
+            })
+        )
     )
     .join(' ')
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,17 +1,20 @@
 // We do this locally just to trim the size of the records a bit
 import sw from 'stopword'
-import { SanityDocumentStub } from '@sanity/client'
-import { SearchIndex } from 'algoliasearch'
-import { AlgoliaRecord } from 'types'
+import {SanityDocumentStub} from '@sanity/client'
+import {SearchIndex} from 'algoliasearch'
+import {AlgoliaRecord} from 'types'
 
 export const sleep = (ms: number) => {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 // Properties that always should exist (only objectID is strictly needed from Algolia)
-export const standardValues = (doc: SanityDocumentStub) => {
+export const standardValues = (
+  doc: SanityDocumentStub,
+  objectIdModifier?: string,
+) => {
   return {
-    objectID: doc._id,
+    objectID: objectIdModifier ? `${doc._id}-${objectIdModifier}` : doc._id,
     type: doc._type,
     rev: doc._rev,
   }
@@ -20,7 +23,7 @@ export const standardValues = (doc: SanityDocumentStub) => {
 // TODO: Probably want to support other languages besides English for the stopwords
 export const flattenBlocks = (
   blocks: Record<string, any>[],
-  removeStopWords = false
+  removeStopWords = false,
 ) => {
   return [].concat
     .apply(
@@ -31,15 +34,15 @@ export const flattenBlocks = (
           b.children
             .filter(
               (c: Record<string, any>) =>
-                typeof c.text === 'string' && c.text.length > 0
+                typeof c.text === 'string' && c.text.length > 0,
             )
             .map((c: Record<string, any>) => {
               if (removeStopWords) {
                 return sw.removeStopwords(c.text.split(' ')).join(' ')
               }
               return c.text
-            })
-        )
+            }),
+        ),
     )
     .join(' ')
 }

--- a/test/indexer.test.ts
+++ b/test/indexer.test.ts
@@ -1,6 +1,6 @@
-import indexer, {indexMapProjection} from '../src/index'
+import indexer, { indexMapProjection } from '../src/index'
 import fixture from './fixtures/internalFaq.json'
-import {SearchIndex} from 'algoliasearch'
+import { SearchIndex } from 'algoliasearch'
 
 const mockIndex = {} as SearchIndex
 
@@ -8,9 +8,9 @@ describe('transform', () => {
   it('includes standard values for some standard properties', () => {
     const algo = indexer(
       {
-        internalFaq: {index: mockIndex},
+        internalFaq: { index: mockIndex },
       },
-      () => ({}),
+      () => ({})
     )
 
     const record = algo.transform([fixture])[0]
@@ -20,7 +20,7 @@ describe('transform', () => {
   })
 
   it('serialized according to passed function', () => {
-    const algo = indexer({internalFaq: {index: mockIndex}}, (document) => {
+    const algo = indexer({ internalFaq: { index: mockIndex } }, (document) => {
       return {
         title: document.title,
         body: 'flattened body',
@@ -39,7 +39,7 @@ describe('transform', () => {
   })
 
   it('handles array returned from serializer', () => {
-    const algo = indexer({internalFaq: {index: mockIndex}}, (document) => {
+    const algo = indexer({ internalFaq: { index: mockIndex } }, (document) => {
       return [
         {
           title: `${document.title} 01`,
@@ -65,7 +65,7 @@ describe('transform', () => {
   })
 
   it('handles objectID override with array returned from serializer', () => {
-    const algo = indexer({internalFaq: {index: mockIndex}}, (document) => {
+    const algo = indexer({ internalFaq: { index: mockIndex } }, (document) => {
       return [
         {
           title: `${document.title} 01`,
@@ -88,7 +88,7 @@ describe('transform', () => {
   })
 
   it('can override default values', () => {
-    const algo = indexer({internalFaq: {index: mockIndex}}, (_document) => {
+    const algo = indexer({ internalFaq: { index: mockIndex } }, (_document) => {
       return {
         objectId: 'totally custom',
         type: 'invented',
@@ -118,9 +118,9 @@ describe('type index map', () => {
     }
 
     const indexMap = {
-      post: {index: postIndex as unknown as SearchIndex},
+      post: { index: (postIndex as unknown) as SearchIndex },
       article: {
-        index: articleIndex as unknown as SearchIndex,
+        index: (articleIndex as unknown) as SearchIndex,
         projection: `{ authors[]-> }`,
       },
     }
@@ -151,19 +151,19 @@ describe('webhookSync', () => {
 
     const i = indexer(
       {
-        post: {index: postIndex as unknown as SearchIndex},
+        post: { index: (postIndex as unknown) as SearchIndex },
         article: {
-          index: articleIndex as unknown as SearchIndex,
+          index: (articleIndex as unknown) as SearchIndex,
           projection: '{"title": "Hardcode"}',
         },
       },
       () => ({
         title: 'Hello',
       }),
-      (document) => document._id !== 'ignore-me',
+      (document) => document._id !== 'ignore-me'
     )
 
-    const client = {fetch: jest.fn()}
+    const client = { fetch: jest.fn() }
 
     // Fake a result from Sanity
     client.fetch.mockResolvedValueOnce([
@@ -205,7 +205,7 @@ describe('webhookSync', () => {
     expect(client.fetch.mock.calls[0][0]).toContain('_type == "post" => {...}')
     // Check the custom projection
     expect(client.fetch.mock.calls[0][0]).toContain(
-      '_type == "article" => {"title": "Hardcode"}',
+      '_type == "article" => {"title": "Hardcode"}'
     )
     expect(client.fetch.mock.calls[0][1]).toMatchObject({
       created: ['create-me', 'create-me-too'],
@@ -217,12 +217,12 @@ describe('webhookSync', () => {
     expect(articleIndex.saveObjects.mock.calls.length).toBe(1)
 
     const savedPostIndexIds = postIndex.saveObjects.mock.calls[0][0].map(
-      (object: Record<string, any>) => object['objectID'],
+      (object: Record<string, any>) => object['objectID']
     )
     expect(savedPostIndexIds).toEqual(['create-me', 'update-me'])
 
     const savedArticleIndexIds = articleIndex.saveObjects.mock.calls[0][0].map(
-      (object: Record<string, any>) => object['objectID'],
+      (object: Record<string, any>) => object['objectID']
     )
     expect(savedArticleIndexIds).toEqual(['create-me-too'])
 


### PR DESCRIPTION
When sending long articles from sanity to algolia, I ran into quite a few document size limits. [The recommended way](https://www.algolia.com/doc/guides/managing-results/refine-results/grouping/#handling-large-records) of dealing with this is to split the article up by paragraph and create separate objects in algolia. 

![article](https://media1.giphy.com/media/cInvQ1XCV4TcEPwVrx/giphy.gif?cid=74e95743261zikk8nqp55ja9elpa6qy9qjq9sv0w190x05aa&rid=giphy.gif&ct=g)