### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ const types = ["article", "page", "product", "author"];
 const query = `* [_type in $types && !(_id in path("drafts.**"))][]._id`
 
 sanity.fetch(query, { types }).then(ids => 
-  sanityAlgolia.webhookSync(client, { ids: { created: ids, updated: [], deleted: [] }})
+  sanityAlgolia.webhookSync(sanity, { ids: { created: ids, updated: [], deleted: [] }})
 )
 ```
 


### PR DESCRIPTION
Minor bug fix to example code. `sanityClient` was named as `sanity` one place and referred to as `client` another place.