### PR TITLE
Export TypeConfig and IndexMap

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,12 @@ import {
 
 export { flattenBlocks } from './util'
 
-type TypeConfig = {
+export type TypeConfig = {
   index: SearchIndex
   projection?: string
 }
 
-type IndexMap = {
+export type IndexMap = {
   [key: string]: TypeConfig
 }
 


### PR DESCRIPTION
These types are used as parameters for exported functions‚ so they should also be exported so a consumer doesn't have to copy the type definitions to be able to create the objects outside of function calls.