### PR TITLE
Fixed not waiting for result of deleteObjects

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,8 +110,8 @@ const indexer = (
     const recordsToDelete = deleted.concat(hiddenIds)
 
     if (recordsToDelete.length > 0) {
-      for await (const typeIndexConfig of Object.values(typeIndexMap)) {
-        typeIndexConfig.index.deleteObjects(recordsToDelete)
+      for (const typeIndexConfig of Object.values(typeIndexMap)) {
+        await typeIndexConfig.index.deleteObjects(recordsToDelete)
       }
     }
   }


### PR DESCRIPTION
`for await` is only useful if the iterable object is an async iterable, which `Object.values(typeIndexMap)` is not. As the actual promise is `typeIndexConfig.index.deleteObjects(recordsToDelete)`, that meant that execution would resume no matter if that operation was completed (or threw an error) or not. This PR fixes this by awaiting the actual promise.